### PR TITLE
Make Calendar quickstart target Java 8

### DIFF
--- a/calendar/quickstart/build.gradle
+++ b/calendar/quickstart/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'CalendarQuickstart'
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 version = '1.0'
 
 repositories {


### PR DESCRIPTION
Calendar quickstart works as is with Java 8 and will still be compatible with Java 7.