### PR TITLE
Use a fixed port for auth callbacks

### DIFF
--- a/adminSDK/directory/quickstart/src/main/java/AdminSDKDirectoryQuickstart.java
+++ b/adminSDK/directory/quickstart/src/main/java/AdminSDKDirectoryQuickstart.java
@@ -64,7 +64,8 @@ public class AdminSDKDirectoryQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/adminSDK/reports/quickstart/src/main/java/AdminSDKReportsQuickstart.java
+++ b/adminSDK/reports/quickstart/src/main/java/AdminSDKReportsQuickstart.java
@@ -64,7 +64,8 @@ public class AdminSDKReportsQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/adminSDK/reseller/quickstart/src/main/java/AdminSDKResellerQuickstart.java
+++ b/adminSDK/reseller/quickstart/src/main/java/AdminSDKResellerQuickstart.java
@@ -64,7 +64,8 @@ public class AdminSDKResellerQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/appsScript/quickstart/src/main/java/AppsScriptQuickstart.java
+++ b/appsScript/quickstart/src/main/java/AppsScriptQuickstart.java
@@ -66,7 +66,8 @@ public class AppsScriptQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/calendar/quickstart/src/main/java/CalendarQuickstart.java
+++ b/calendar/quickstart/src/main/java/CalendarQuickstart.java
@@ -65,7 +65,8 @@ public class CalendarQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/calendar/sync/src/main/java/com/google/api/services/samples/calendar/sync/Utils.java
+++ b/calendar/sync/src/main/java/com/google/api/services/samples/calendar/sync/Utils.java
@@ -90,7 +90,8 @@ public class Utils {
     GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(httpTransport,
         JSON_FACTORY, clientSecrets, scopes).setDataStoreFactory(dataStoreFactory).build();
     // Authorize.
-    return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+    LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+    return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
   }
 
   /** Gets the datastore factory used in these samples. */

--- a/classroom/quickstart/src/main/java/ClassroomQuickstart.java
+++ b/classroom/quickstart/src/main/java/ClassroomQuickstart.java
@@ -63,7 +63,8 @@ public class ClassroomQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/drive/quickstart/src/main/java/DriveQuickstart.java
+++ b/drive/quickstart/src/main/java/DriveQuickstart.java
@@ -64,7 +64,8 @@ public class DriveQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/gmail/quickstart/src/main/java/GmailQuickstart.java
+++ b/gmail/quickstart/src/main/java/GmailQuickstart.java
@@ -64,7 +64,8 @@ public class GmailQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/people/quickstart/src/main/java/PeopleQuickstart.java
+++ b/people/quickstart/src/main/java/PeopleQuickstart.java
@@ -65,7 +65,8 @@ public class PeopleQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/sheets/quickstart/src/main/java/SheetsQuickstart.java
+++ b/sheets/quickstart/src/main/java/SheetsQuickstart.java
@@ -63,7 +63,8 @@ public class SheetsQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     /**

--- a/slides/quickstart/src/main/java/SlidesQuickstart.java
+++ b/slides/quickstart/src/main/java/SlidesQuickstart.java
@@ -64,7 +64,8 @@ public class SlidesQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {

--- a/tasks/quickstart/src/main/java/TasksQuickstart.java
+++ b/tasks/quickstart/src/main/java/TasksQuickstart.java
@@ -64,7 +64,8 @@ public class TasksQuickstart {
                 .setDataStoreFactory(new FileDataStoreFactory(new java.io.File(TOKENS_DIRECTORY_PATH)))
                 .setAccessType("offline")
                 .build();
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        LocalServerReceiver receier = new LocalServerReceiver.Builder().setPort(8888).build();
+        return new AuthorizationCodeInstalledApp(flow, receier).authorize("user");
     }
 
     public static void main(String... args) throws IOException, GeneralSecurityException {


### PR DESCRIPTION
The random port is a problem for developers that run these samples in containers or other restrictive environments where they need to whitelist ports. Fixes #35.