### PR TITLE
fix: Use JDK 11 (8 is broken)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
-  # - oraclejdk9
+  - oraclejdk11
 # Use a Build Matrix for subdirs (https://lord.io/blog/2014/travis-multiple-subdirs/)
 env:
   - DIR=adminSDK/alertcenter/quickstart


### PR DESCRIPTION
Travis is failing because JDK 8 is broken.

Use a newer version.
https://travis-ci.community/t/install-jdk-sh-failing-for-openjdk9-and-10/3998