### PR TITLE
Update google-api-services-docs dependency

### DIFF
--- a/docs/quickstart/build.gradle
+++ b/docs/quickstart/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-docs:v1-rev20190128-1.28.0'
+    compile 'com.google.api-client:google-api-client:1.30.1'
+    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.1'
+    compile 'com.google.apis:google-api-services-docs:v1-rev20190827-1.30.1'
 }


### PR DESCRIPTION
The current example dependency version does not include the APIs used in the [inserting and deleting tables](https://developers.google.com/docs/api/how-tos/tables#inserting_and_deleting_tables) section.