### PR TITLE
Bump libs versions

### DIFF
--- a/sheets/quickstart/build.gradle
+++ b/sheets/quickstart/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-sheets:v4-rev516-1.23.0'
+    compile 'com.google.api-client:google-api-client:1.30.4'
+    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.4'
+    compile 'com.google.apis:google-api-services-sheets:v4-rev581-1.25.0'
 }


### PR DESCRIPTION
google-api-client:1.23.0 has transitive dependency with guava-jdk5 (2014) which is not compatible with newer versions and is the cause of assembly errors.