### PR TITLE
Bump versions of Java libraries for quick-start

### DIFF
--- a/gmail/quickstart/build.gradle
+++ b/gmail/quickstart/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
+    compile 'com.google.api-client:google-api-client:1.30.9'
+    compile 'com.google.oauth-client:google-oauth-client-jetty:1.30.6'
+    compile 'com.google.apis:google-api-services-gmail:v1-rev20200504-1.30.9'
 }


### PR DESCRIPTION
These versions are pretty old and some classes are not properly marked as deprecated.

The rest of the quickstart could probably use updating but I wanted to do something simple to start.